### PR TITLE
feature/issue 11

### DIFF
--- a/src/modules/user/repos/UserRepository.ts
+++ b/src/modules/user/repos/UserRepository.ts
@@ -14,4 +14,5 @@ export interface UserRepository {
   listAll(): Promise<User[]>
   loadUserFromTokenAndId(id: string, token: string): Promise<User | null>
   loadById(id: string): Promise<User | null>
+  deleteUserById(id: string): Promise<User>
 }

--- a/src/modules/user/repos/implementations/PrismaUserRepository.test.ts
+++ b/src/modules/user/repos/implementations/PrismaUserRepository.test.ts
@@ -102,4 +102,14 @@ describe('PrismaUserRepository', () => {
       expect(result).toEqual(null)
     })
   })
+
+  describe('deleteUserById', () => {
+    it('should return deleted user', async () => {
+      const user = await prisma.user.create({
+        data: userFactory(1)
+      })
+      const result = await sut.deleteUserById(user.id)
+      expect(result).toEqual(user)
+    })
+  })
 })

--- a/src/modules/user/repos/implementations/PrismaUserRepository.ts
+++ b/src/modules/user/repos/implementations/PrismaUserRepository.ts
@@ -42,4 +42,10 @@ export class PrismaUserRepository implements UserRepository {
       where: { id }
     })
   }
+
+  async deleteUserById (id: string): Promise<User> {
+    return await this.prisma.user.delete({
+      where: { id }
+    })
+  }
 }

--- a/src/modules/user/useCases/removeUser/RemoveUser.ts
+++ b/src/modules/user/useCases/removeUser/RemoveUser.ts
@@ -1,0 +1,7 @@
+export interface RemoveUserInputDTO {
+  userId: string
+}
+
+export interface RemoveUser {
+  execute(data: RemoveUserInputDTO): Promise<void>
+}

--- a/src/modules/user/useCases/removeUser/RemoveUserController.ts
+++ b/src/modules/user/useCases/removeUser/RemoveUserController.ts
@@ -1,0 +1,22 @@
+import { Controller } from '../../../../shared/infra/http/Controller'
+import { HttpAuthenticatedRequest, HttpResponse, noContent, serverError } from '../../../../shared/infra/http/http'
+import { RemoveUser } from './RemoveUser'
+
+export type RemoveUserControllerRequest = HttpAuthenticatedRequest<any, any>
+
+export class RemoveUserController extends Controller {
+  constructor (private readonly removeUserUseCase: RemoveUser) {
+    super()
+  }
+
+  async execute (httpRequest: RemoveUserControllerRequest): Promise<HttpResponse<any>> {
+    try {
+      await this.removeUserUseCase.execute({
+        userId: httpRequest.authenticatedUser.id
+      })
+      return noContent()
+    } catch (error) {
+      return serverError(error)
+    }
+  }
+}

--- a/src/modules/user/useCases/removeUser/RemoveUserUseCase.ts
+++ b/src/modules/user/useCases/removeUser/RemoveUserUseCase.ts
@@ -1,0 +1,10 @@
+import { UserRepository } from '../../repos/UserRepository'
+import { RemoveUser, RemoveUserInputDTO } from './RemoveUser'
+
+export class RemoveUserUseCase implements RemoveUser {
+  constructor (private readonly userRepository: UserRepository) {}
+
+  async execute (data: RemoveUserInputDTO): Promise<void> {
+    await this.userRepository.deleteUserById(data.userId)
+  }
+}

--- a/src/modules/user/useCases/removeUser/__tests__/RemoveUserController.spec.ts
+++ b/src/modules/user/useCases/removeUser/__tests__/RemoveUserController.spec.ts
@@ -1,0 +1,46 @@
+import { mock } from 'jest-mock-extended'
+
+import userFactory from '../../../../../../tests/factories/userFactory'
+import { noContent, serverError } from '../../../../../shared/infra/http/http'
+import { RemoveUser } from '../RemoveUser'
+import { RemoveUserController, RemoveUserControllerRequest } from '../RemoveUserController'
+
+const makeSut = () => {
+  const removeUserMock = mock<RemoveUser>()
+  const sut = new RemoveUserController(removeUserMock)
+  return { sut, removeUserMock }
+}
+
+const makeRequestData = (): RemoveUserControllerRequest => ({
+  authenticatedUser: userFactory(1)
+})
+
+describe('RemoveUserController', () => {
+  let requestData: RemoveUserControllerRequest
+
+  beforeEach(() => {
+    requestData = makeRequestData()
+  })
+
+  it('should call RemoveUser use case with correct value', async () => {
+    const { sut, removeUserMock } = makeSut()
+    await sut.execute(requestData)
+    expect(removeUserMock.execute).toHaveBeenCalledWith({
+      userId: requestData.authenticatedUser.id
+    })
+  })
+
+  it('should return server error if RemoveUser throws', async () => {
+    const { sut, removeUserMock } = makeSut()
+    removeUserMock.execute.mockRejectedValueOnce(new Error())
+
+    const result = await sut.execute(requestData)
+    expect(result).toEqual(serverError(new Error()))
+  })
+
+  it('should return no contenton success', async () => {
+    const { sut } = makeSut()
+    const result = await sut.execute(requestData)
+    expect(result).toEqual(noContent())
+  })
+})

--- a/src/modules/user/useCases/removeUser/__tests__/RemoveUserUseCase.spec.ts
+++ b/src/modules/user/useCases/removeUser/__tests__/RemoveUserUseCase.spec.ts
@@ -1,0 +1,46 @@
+import faker from 'faker'
+import { mock } from 'jest-mock-extended'
+
+import { UserRepository } from '../../../repos/UserRepository'
+import { RemoveUserInputDTO } from '../RemoveUser'
+import { RemoveUserUseCase } from '../RemoveUserUseCase'
+
+const makeSut = () => {
+  const userRepositoryMock = mock<UserRepository>()
+  const sut = new RemoveUserUseCase(userRepositoryMock)
+
+  return {
+    sut,
+    userRepositoryMock
+  }
+}
+
+const makeInput = (): RemoveUserInputDTO => ({
+  userId: faker.datatype.uuid()
+})
+
+describe('RemoveUserUseCase', () => {
+  let input: RemoveUserInputDTO
+
+  beforeEach(() => {
+    input = makeInput()
+  })
+
+  it('should call UserRepository.deleteById with correct value', async () => {
+    const { sut, userRepositoryMock } = makeSut()
+    await sut.execute(input)
+    expect(userRepositoryMock.deleteUserById).toHaveBeenCalledWith(input.userId)
+  })
+
+  it('should throw id UserRepository.deleteById throws', async () => {
+    const { sut, userRepositoryMock } = makeSut()
+    userRepositoryMock.deleteUserById.mockRejectedValueOnce(new Error())
+    await expect(sut.execute(input)).rejects.toThrow()
+  })
+
+  it('should return nothing on success', async () => {
+    const { sut } = makeSut()
+    const result = await sut.execute(input)
+    expect(result).toBeUndefined()
+  })
+})

--- a/src/shared/infra/http/docs/api-schema.json
+++ b/src/shared/infra/http/docs/api-schema.json
@@ -203,6 +203,33 @@
           }
         }
       }
+    },
+    "/user/me": {
+      "delete": {
+        "security": [
+          {
+            "authorization": []
+          }
+        ],
+        "tags": [
+          "User"
+        ],
+        "responses": {
+          "204": {
+            "description": "Ok. Deleted user from authorization token"
+          },
+          "401": {
+            "description": "Return a unauthorized or invalid token error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errorPayload"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {

--- a/src/shared/infra/http/http.ts
+++ b/src/shared/infra/http/http.ts
@@ -49,6 +49,11 @@ export const created = <T = any> (data: T): HttpResponse<T> => ({
   data
 })
 
+export const noContent = (): HttpResponse => ({
+  statusCode: 204,
+  data: null
+})
+
 export const unauthorized = (error ?: Error): HttpResponse => ({
   statusCode: 401,
   data: error || new AppErrors.UnauthorizedError()

--- a/src/shared/infra/http/routes/__tests__/user.test.ts
+++ b/src/shared/infra/http/routes/__tests__/user.test.ts
@@ -290,6 +290,10 @@ describe('User Routes', () => {
         .set('authorization', makeBearerToken(user.accessToken!))
         .send()
       expect(response.statusCode).toEqual(204)
+      const deletedUser = await prisma.user.findUnique({
+        where: { id: user.id }
+      })
+      expect(deletedUser).toBeNull()
     })
   })
 })

--- a/src/shared/infra/http/routes/user.ts
+++ b/src/shared/infra/http/routes/user.ts
@@ -8,6 +8,8 @@ import { GetUserUseCase } from '../../../../modules/user/useCases/getUser/GetUse
 import { GetUsersController } from '../../../../modules/user/useCases/getUsers/GetUsersController'
 import { GetUsersUseCase } from '../../../../modules/user/useCases/getUsers/GetUsersUseCase'
 import { RegisterUserController } from '../../../../modules/user/useCases/register/RegisterUserController'
+import { RemoveUserController } from '../../../../modules/user/useCases/removeUser/RemoveUserController'
+import { RemoveUserUseCase } from '../../../../modules/user/useCases/removeUser/RemoveUserUseCase'
 import { expressMiddlewareAdapter } from '../../adapters/expressMiddlewareAdapter'
 import { expressAuthenticatedRouteAdapter, expressRouteAdapter } from '../../adapters/expressRouteAdapter'
 import { makeJwtAdapter } from '../../factories/makeJwtAdapter'
@@ -42,9 +44,16 @@ export const makeGetUserController = (prisma: PrismaClient) => {
   return new GetUserController(getUserUseCase)
 }
 
+export const makeRemoveUserController = (prisma: PrismaClient) => {
+  const userRepository = makePrismaUserRepository(prisma)
+  const removeUserUseCase = new RemoveUserUseCase(userRepository)
+  return new RemoveUserController(removeUserUseCase)
+}
+
 export const makeUsersRouter = (prisma: PrismaClient) => {
   const router = Router()
   router.post('/user', expressRouteAdapter(makeRegisterUserController(prisma)))
+
   router.get('/user',
     expressMiddlewareAdapter(new AuthMidddleware(makeJwtAdapter(), makePrismaUserRepository(prisma))),
     expressAuthenticatedRouteAdapter(makeGetUsersController(prisma))
@@ -52,6 +61,11 @@ export const makeUsersRouter = (prisma: PrismaClient) => {
   router.get('/user/:userId',
     expressMiddlewareAdapter(new AuthMidddleware(makeJwtAdapter(), makePrismaUserRepository(prisma))),
     expressAuthenticatedRouteAdapter(makeGetUserController(prisma))
+  )
+
+  router.delete('/user/me',
+    expressMiddlewareAdapter(new AuthMidddleware(makeJwtAdapter(), makePrismaUserRepository(prisma))),
+    expressAuthenticatedRouteAdapter(makeRemoveUserController(prisma))
   )
   return router
 }

--- a/tests/utils/makeBearerToken.ts
+++ b/tests/utils/makeBearerToken.ts
@@ -1,0 +1,3 @@
+export function makeBearerToken (token: string) {
+  return `Bearer ${token}`
+}


### PR DESCRIPTION
- feat: add noContent http helper
- feat: add RemoveUser use case interface
- feat: add RemoveUserController
- test: add RemoveUserController unit tests
- feat: add deleteUserById to UserRepository interface
- feat: add RemoveUserUseCase
- test: add RemoveUserUseCase unit tests
- feat: add deleteUserById implementation in PrismaUserRepository
- test: feat: add deleteUserById integration tests in PrismaUserRepository
- feat: add DELETE /user/me route
- test: add DELETE user/me route integration tests
- test: validate that user is deleted after DELETE user/me
- docs: add DELETE user/me swagger docs

closes #11 
