### PR TITLE
feature(issue-18): get posts by id route

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postpress",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "1. [Database](./docs/database.md) 2. Routes    1. [User](./docs/user-routes.md)",
   "main": "index.js",
   "directories": {

--- a/src/modules/post/repos/PostRepository.ts
+++ b/src/modules/post/repos/PostRepository.ts
@@ -11,4 +11,5 @@ export interface PostRepositoryCreateDTO {
 export interface PostRepository {
   create(data: PostRepositoryCreateDTO): Promise<PostWithUser>
   getAll(): Promise<PostWithUser[]>
+  loadById(id: string): Promise<PostWithUser | null>
 }

--- a/src/modules/post/repos/implementations/PrismaPostRepository.test.ts
+++ b/src/modules/post/repos/implementations/PrismaPostRepository.test.ts
@@ -71,4 +71,25 @@ describe('PrismaPostRepository', () => {
       })
     })
   })
+
+  describe('loadById', () => {
+    it('should return post with user', async () => {
+      const user = await prisma.user.create({
+        data: userFactory(1)
+      })
+      const createdPost = await prisma.post.create({
+        data: {
+          ...omit(postFactory(1), 'userId'),
+          user: {
+            connect: {
+              id: user.id
+            }
+          }
+        }
+      })
+      const post = await sut.loadById(createdPost.id)
+      expect(post!.id).toBeDefined()
+      expect(post!.user.id).toEqual(user.id)
+    })
+  })
 })

--- a/src/modules/post/repos/implementations/PrismaPostRepository.ts
+++ b/src/modules/post/repos/implementations/PrismaPostRepository.ts
@@ -27,4 +27,11 @@ export class PrismaPostRepository implements PostRepository {
       include: { user: true }
     })
   }
+
+  loadById (id: string): Promise<PostWithUser | null> {
+    return this.prisma.post.findUnique({
+      where: { id },
+      include: { user: true }
+    })
+  }
 }

--- a/src/modules/post/useCases/getPost/GetPost.ts
+++ b/src/modules/post/useCases/getPost/GetPost.ts
@@ -1,0 +1,13 @@
+import { PresentationPost } from '../../models/PresentationPost'
+
+export interface GetPostInputDTO {
+  postId: string
+}
+
+export interface GetPostReponseDTO {
+  post: PresentationPost
+}
+
+export interface GetPost {
+  execute(data: GetPostInputDTO): Promise<GetPostReponseDTO>
+}

--- a/src/modules/post/useCases/getPost/GetPostController.ts
+++ b/src/modules/post/useCases/getPost/GetPostController.ts
@@ -1,0 +1,31 @@
+import { Controller } from '../../../../shared/infra/http/Controller'
+import { HttpRequest, HttpResponse, notFound, ok, serverError } from '../../../../shared/infra/http/http'
+import { GetPost } from './GetPost'
+import { GetPostErrors } from './GetPostErrors'
+
+export type GetPostControllerRequest = HttpRequest<any, {
+  postId: string
+}>
+
+export class GetPostController extends Controller {
+  constructor (private readonly getPost: GetPost) {
+    super()
+  }
+
+  async execute (data: GetPostControllerRequest): Promise<HttpResponse<any>> {
+    try {
+      const { post } = await this.getPost.execute({
+        postId: data.params?.postId!
+      })
+      return ok(post)
+    } catch (error) {
+      if (error instanceof Error) {
+        switch (error.constructor) {
+          case GetPostErrors.PostNotFound:
+            return notFound(error)
+        }
+      }
+      return serverError(error)
+    }
+  }
+}

--- a/src/modules/post/useCases/getPost/GetPostErrors.ts
+++ b/src/modules/post/useCases/getPost/GetPostErrors.ts
@@ -1,0 +1,8 @@
+export namespace GetPostErrors {
+  export class PostNotFound extends Error {
+    constructor () {
+      super('Post não existe')
+      this.name = 'GetPostErrors.PostNotFound'
+    }
+  }
+}

--- a/src/modules/post/useCases/getPost/GetPostUseCase.ts
+++ b/src/modules/post/useCases/getPost/GetPostUseCase.ts
@@ -1,0 +1,16 @@
+import { PostMapper } from '../../models/mapper/PostMapper'
+import { PostRepository } from '../../repos/PostRepository'
+import { GetPost, GetPostInputDTO, GetPostReponseDTO } from './GetPost'
+import { GetPostErrors } from './GetPostErrors'
+
+export class GetPostUseCase implements GetPost {
+  constructor (private readonly postRepository: PostRepository) {}
+
+  async execute (data: GetPostInputDTO): Promise<GetPostReponseDTO> {
+    const post = await this.postRepository.loadById(data.postId)
+    if (!post) throw new GetPostErrors.PostNotFound()
+
+    const presentationPost = PostMapper.toPresentation(post)
+    return { post: presentationPost }
+  }
+}

--- a/src/modules/post/useCases/getPost/__tests__/GetPostController.spec.ts
+++ b/src/modules/post/useCases/getPost/__tests__/GetPostController.spec.ts
@@ -1,0 +1,66 @@
+import faker from 'faker'
+import { mock } from 'jest-mock-extended'
+
+import presentationPostFactory from '../../../../../../tests/factories/presentationPostFactory'
+import { notFound, ok, serverError } from '../../../../../shared/infra/http/http'
+import { GetPost } from '../GetPost'
+import { GetPostController, GetPostControllerRequest } from '../GetPostController'
+import { GetPostErrors } from '../GetPostErrors'
+
+const makeSut = () => {
+  const getPostMock = mock<GetPost>()
+
+  // golden path mock
+  const post = presentationPostFactory(1)
+  getPostMock.execute.mockResolvedValue({ post })
+
+  const sut = new GetPostController(getPostMock)
+
+  return {
+    sut,
+    getPostMock,
+    post
+  }
+}
+
+const makeRequest = (): GetPostControllerRequest => ({
+  params: {
+    postId: faker.datatype.uuid()
+  }
+})
+
+describe('GetPostController', () => {
+  let request: GetPostControllerRequest
+
+  beforeEach(() => {
+    request = makeRequest()
+  })
+
+  it('should call GetPost with correct value', async () => {
+    const { sut, getPostMock } = makeSut()
+    await sut.execute(request)
+    expect(getPostMock.execute).toHaveBeenCalledWith({
+      postId: request.params?.postId
+    })
+  })
+
+  it('should return notFound if GetUsers throws a GetPostErrors.PostNotFound errors', async () => {
+    const { sut, getPostMock } = makeSut()
+    getPostMock.execute.mockRejectedValueOnce(new GetPostErrors.PostNotFound())
+    const result = await sut.execute(request)
+    expect(result).toEqual(notFound(new GetPostErrors.PostNotFound()))
+  })
+
+  it('should return serverError if GetUsers throws a unkown error', async () => {
+    const { sut, getPostMock } = makeSut()
+    getPostMock.execute.mockRejectedValueOnce(new Error())
+    const result = await sut.execute(request)
+    expect(result).toEqual(serverError(new Error()))
+  })
+
+  it('should return ok with post on success', async () => {
+    const { sut, post } = makeSut()
+    const result = await sut.execute(request)
+    expect(result).toEqual(ok(post))
+  })
+})

--- a/src/modules/post/useCases/getPost/__tests__/GetPostUseCase.spec.ts
+++ b/src/modules/post/useCases/getPost/__tests__/GetPostUseCase.spec.ts
@@ -1,0 +1,54 @@
+import faker from 'faker'
+import { mock } from 'jest-mock-extended'
+
+import postWithUserFactory from '../../../../../../tests/factories/postWithUserFactory'
+import { PostRepository } from '../../../repos/PostRepository'
+import { GetPostInputDTO } from '../GetPost'
+import { GetPostUseCase } from '../GetPostUseCase'
+
+const makeSut = () => {
+  const postRepositoryMock = mock<PostRepository>()
+
+  const postWithUser = postWithUserFactory(1)
+  // golden path mock
+  postRepositoryMock.loadById.mockResolvedValue(postWithUser)
+
+  const sut = new GetPostUseCase(postRepositoryMock)
+
+  return {
+    sut,
+    postRepositoryMock,
+    postWithUser
+  }
+}
+
+const makeInput = (): GetPostInputDTO => ({
+  postId: faker.datatype.uuid()
+})
+
+describe('GetPostUseCase', () => {
+  let input: GetPostInputDTO
+
+  beforeEach(() => {
+    input = makeInput()
+  })
+
+  it('should call PostRepository.loadById with correct value', async () => {
+    const { sut, postRepositoryMock } = makeSut()
+    await sut.execute(input)
+    expect(postRepositoryMock.loadById).toHaveBeenCalledWith(input.postId)
+  })
+
+  it('should throw a PostNotFoundError if post is not found', async () => {
+    const { sut, postRepositoryMock } = makeSut()
+    postRepositoryMock.loadById.mockResolvedValueOnce(null)
+    const promise = sut.execute(input)
+    expect(promise).rejects.toThrow()
+  })
+
+  it('should return post on success', async () => {
+    const { sut } = makeSut()
+    const result = await sut.execute(input)
+    expect(result.post).toBeDefined()
+  })
+})

--- a/src/shared/infra/http/docs/api-schema.json
+++ b/src/shared/infra/http/docs/api-schema.json
@@ -316,6 +316,61 @@
           }
         }
       }
+    },
+    "/post/{postId}": {
+      "parameters": [
+        {
+          "in": "path",
+          "name": "postId",
+          "schema": {
+            "type": "string"
+          },
+          "required": true,
+          "description": "ID of a blog Post"
+        }
+      ],
+      "get": {
+        "security": [
+          {
+            "authorization": []
+          }
+        ],
+        "tags": [
+          "Post"
+        ],
+        "responses": {
+          "200": {
+            "description": "Blog post",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/presentationPost"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Blog post not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errorPayload"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized or Invalid token error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errorPayload"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {

--- a/src/shared/infra/http/routes/__tests__/post.test.ts
+++ b/src/shared/infra/http/routes/__tests__/post.test.ts
@@ -1,4 +1,5 @@
 import { PrismaClient, User } from '@prisma/client'
+import faker from 'faker'
 import { omit } from 'lodash'
 import request from 'supertest'
 
@@ -150,6 +151,81 @@ describe('Post Routes', () => {
         .send({ title: 'title', content: 'content' })
       expect(response.statusCode).toEqual(200)
       expect(response.body.length).toEqual(2)
+    })
+  })
+
+  describe('GET /post/:postId', () => {
+    const makeUrl = (postId: string) => {
+      return `/post/${postId}`
+    }
+
+    it('should return 401 if authentication is not provided', async () => {
+      const response = await request(app)
+        .get(makeUrl(faker.datatype.uuid()))
+        .send()
+      expect(response.statusCode).toEqual(401)
+      expect(response.body).toMatchInlineSnapshot(`
+        Object {
+          "message": "Token não encontrado",
+        }
+      `)
+    })
+
+    it('should return 401 if an invalid authentication is provided', async () => {
+      const response = await request(app)
+        .get(makeUrl(faker.datatype.uuid()))
+        .set('authorization', 'Bearer random')
+        .send()
+      expect(response.statusCode).toEqual(401)
+      expect(response.body).toMatchInlineSnapshot(`
+        Object {
+          "message": "Token expirado ou inválido",
+        }
+      `)
+    })
+
+    it('should 200 on success', async () => {
+      await prisma.post.create({
+        data: {
+          ...omit(postFactory(1), 'userId'),
+          user: {
+            connect: {
+              id: authUser.id
+            }
+          }
+        }
+      })
+      const post = await prisma.post.create({
+        data: {
+          ...omit(postFactory(1), 'userId'),
+          user: {
+            connect: {
+              id: authUser.id
+            }
+          }
+        }
+      })
+      const response = await request(app)
+        .get(makeUrl(post.id))
+        .set('authorization', makeBearerToken(authUser.accessToken!))
+        .send({ title: 'title', content: 'content' })
+      expect(response.statusCode).toEqual(200)
+      expect(response.body.id).toEqual(post.id)
+      expect(response.body.title).toEqual(post.title)
+      expect(response.body.user.id).toEqual(authUser.id)
+    })
+
+    it('should return 404 if post does not exists', async () => {
+      const response = await request(app)
+        .get(makeUrl(faker.datatype.uuid()))
+        .set('authorization', makeBearerToken(authUser.accessToken!))
+        .send()
+      expect(response.statusCode).toEqual(404)
+      expect(response.body).toMatchInlineSnapshot(`
+        Object {
+          "message": "Post não existe",
+        }
+      `)
     })
   })
 })

--- a/src/shared/infra/http/routes/post.ts
+++ b/src/shared/infra/http/routes/post.ts
@@ -6,6 +6,8 @@ import { JoiValidatorAdapter } from '../../../../infra/adapters/validation/JoiVa
 import { PrismaPostRepository } from '../../../../modules/post/repos/implementations/PrismaPostRepository'
 import { CreatePostController } from '../../../../modules/post/useCases/createPost/CreatePostController'
 import { CreatePostUseCase } from '../../../../modules/post/useCases/createPost/CreatePostUseCase'
+import { GetPostController } from '../../../../modules/post/useCases/getPost/GetPostController'
+import { GetPostUseCase } from '../../../../modules/post/useCases/getPost/GetPostUseCase'
 import { GetPostsController } from '../../../../modules/post/useCases/getPosts/GetPostsController'
 import { GetPostsUseCase } from '../../../../modules/post/useCases/getPosts/GetPostsUseCase'
 import { expressMiddlewareAdapter } from '../../adapters/expressMiddlewareAdapter'
@@ -32,6 +34,12 @@ const makeGetPostsController = (prisma: PrismaClient) => {
   return new GetPostsController(getPostsUseCase)
 }
 
+const makeGetPostController = (prisma: PrismaClient) => {
+  const prismaPostRepository = new PrismaPostRepository(prisma)
+  const getPostUseCase = new GetPostUseCase(prismaPostRepository)
+  return new GetPostController(getPostUseCase)
+}
+
 export const makePostRoutes = (prisma: PrismaClient) => {
   const router = Router()
   router.post('/post',
@@ -42,6 +50,11 @@ export const makePostRoutes = (prisma: PrismaClient) => {
   router.get('/post',
     expressMiddlewareAdapter(new AuthMidddleware(makeJwtAdapter(), makePrismaUserRepository(prisma))),
     expressAuthenticatedRouteAdapter(makeGetPostsController(prisma))
+  )
+
+  router.get('/post/:postId',
+    expressMiddlewareAdapter(new AuthMidddleware(makeJwtAdapter(), makePrismaUserRepository(prisma))),
+    expressAuthenticatedRouteAdapter(makeGetPostController(prisma))
   )
   return router
 }


### PR DESCRIPTION
- feat: add GetPostController
- test: add GetPostController unit tests
- feat: add GetPostUseCase
- test: add GetPostUseCase unit test
- feat: add loadById implementation on PrismaPostRepository
- test: loadById in PrismaPostRepository integration tests
- feat: add GET /post/:postId route
- test: add GET /post/:postId tests
- docs: add GET /post/:postId swagger docs
- version: bump version to 0.3.0
