### PR TITLE
feature(issue-20): update post

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postpress",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "1. [Database](./docs/database.md) 2. Routes    1. [User](./docs/user-routes.md)",
   "main": "index.js",
   "directories": {

--- a/src/modules/post/models/mapper/PresentationUpdatedPost.ts
+++ b/src/modules/post/models/mapper/PresentationUpdatedPost.ts
@@ -1,0 +1,5 @@
+export interface PresentationUpdatedPost {
+  title: string
+  content: string
+  userId: string
+}

--- a/src/modules/post/repos/PostRepository.ts
+++ b/src/modules/post/repos/PostRepository.ts
@@ -17,5 +17,5 @@ export interface PostRepository {
   create(data: PostRepositoryCreateDTO): Promise<PostWithUser>
   getAll(): Promise<PostWithUser[]>
   loadById(id: string): Promise<PostWithUser | null>
-  update(data: PostRepositoryUpdateDTO): Promise<PostWithUser>
+  update(postId: string, dataToUpdate: PostRepositoryUpdateDTO): Promise<PostWithUser>
 }

--- a/src/modules/post/repos/PostRepository.ts
+++ b/src/modules/post/repos/PostRepository.ts
@@ -8,8 +8,14 @@ export interface PostRepositoryCreateDTO {
   userId: string
 }
 
+export interface PostRepositoryUpdateDTO {
+  title: string
+  content: string
+}
+
 export interface PostRepository {
   create(data: PostRepositoryCreateDTO): Promise<PostWithUser>
   getAll(): Promise<PostWithUser[]>
   loadById(id: string): Promise<PostWithUser | null>
+  update(data: PostRepositoryUpdateDTO): Promise<PostWithUser>
 }

--- a/src/modules/post/repos/implementations/PrismaPostRepository.test.ts
+++ b/src/modules/post/repos/implementations/PrismaPostRepository.test.ts
@@ -1,9 +1,10 @@
 import { PrismaClient } from '@prisma/client'
+import faker from 'faker'
 import { omit } from 'lodash'
 
 import postFactory from '../../../../../tests/factories/postFactory'
 import userFactory from '../../../../../tests/factories/userFactory'
-import { PostRepository, PostRepositoryCreateDTO } from '../PostRepository'
+import { PostRepository, PostRepositoryCreateDTO, PostRepositoryUpdateDTO } from '../PostRepository'
 import { PrismaPostRepository } from './PrismaPostRepository'
 
 describe('PrismaPostRepository', () => {
@@ -90,6 +91,34 @@ describe('PrismaPostRepository', () => {
       const post = await sut.loadById(createdPost.id)
       expect(post!.id).toBeDefined()
       expect(post!.user.id).toEqual(user.id)
+    })
+  })
+
+  describe('update', () => {
+    it('should return updated post', async () => {
+      const user = await prisma.user.create({
+        data: userFactory(1)
+      })
+      const createdPost = await prisma.post.create({
+        data: {
+          ...omit(postFactory(1), 'userId'),
+          user: {
+            connect: {
+              id: user.id
+            }
+          }
+        }
+      })
+
+      const payload: PostRepositoryUpdateDTO = {
+        title: faker.random.words(),
+        content: faker.random.words()
+      }
+      const updatedPost = await sut.update(createdPost.id, payload)
+      expect(updatedPost!.id).toBeDefined()
+      expect(updatedPost.title).toEqual(payload.title)
+      expect(updatedPost.content).toEqual(payload.content)
+      expect(updatedPost!.user.id).toEqual(user.id)
     })
   })
 })

--- a/src/modules/post/repos/implementations/PrismaPostRepository.ts
+++ b/src/modules/post/repos/implementations/PrismaPostRepository.ts
@@ -1,6 +1,6 @@
 import { PrismaClient } from '@prisma/client'
 
-import { PostRepository, PostRepositoryCreateDTO, PostWithUser } from '../PostRepository'
+import { PostRepository, PostRepositoryCreateDTO, PostRepositoryUpdateDTO, PostWithUser } from '../PostRepository'
 
 export class PrismaPostRepository implements PostRepository {
   constructor (private readonly prisma: PrismaClient) {}
@@ -32,6 +32,16 @@ export class PrismaPostRepository implements PostRepository {
     return this.prisma.post.findUnique({
       where: { id },
       include: { user: true }
+    })
+  }
+
+  update (postId: string, dataToUpdate: PostRepositoryUpdateDTO): Promise<PostWithUser> {
+    return this.prisma.post.update({
+      where: { id: postId },
+      data: dataToUpdate,
+      include: {
+        user: true
+      }
     })
   }
 }

--- a/src/modules/post/shared/PostErrors.ts
+++ b/src/modules/post/shared/PostErrors.ts
@@ -1,8 +1,8 @@
-export namespace GetPostErrors {
+export namespace PostErrors {
   export class PostNotFound extends Error {
     constructor () {
       super('Post não existe')
-      this.name = 'GetPostErrors.PostNotFound'
+      this.name = 'PostErrors.PostNotFound'
     }
   }
 }

--- a/src/modules/post/useCases/getPost/GetPostController.ts
+++ b/src/modules/post/useCases/getPost/GetPostController.ts
@@ -1,7 +1,7 @@
 import { Controller } from '../../../../shared/infra/http/Controller'
 import { HttpRequest, HttpResponse, notFound, ok, serverError } from '../../../../shared/infra/http/http'
+import { PostErrors } from '../../shared/PostErrors'
 import { GetPost } from './GetPost'
-import { GetPostErrors } from './GetPostErrors'
 
 export type GetPostControllerRequest = HttpRequest<any, {
   postId: string
@@ -21,7 +21,7 @@ export class GetPostController extends Controller {
     } catch (error) {
       if (error instanceof Error) {
         switch (error.constructor) {
-          case GetPostErrors.PostNotFound:
+          case PostErrors.PostNotFound:
             return notFound(error)
         }
       }

--- a/src/modules/post/useCases/getPost/GetPostUseCase.ts
+++ b/src/modules/post/useCases/getPost/GetPostUseCase.ts
@@ -1,14 +1,14 @@
 import { PostMapper } from '../../models/mapper/PostMapper'
 import { PostRepository } from '../../repos/PostRepository'
+import { PostErrors } from '../../shared/PostErrors'
 import { GetPost, GetPostInputDTO, GetPostReponseDTO } from './GetPost'
-import { GetPostErrors } from './GetPostErrors'
 
 export class GetPostUseCase implements GetPost {
   constructor (private readonly postRepository: PostRepository) {}
 
   async execute (data: GetPostInputDTO): Promise<GetPostReponseDTO> {
     const post = await this.postRepository.loadById(data.postId)
-    if (!post) throw new GetPostErrors.PostNotFound()
+    if (!post) throw new PostErrors.PostNotFound()
 
     const presentationPost = PostMapper.toPresentation(post)
     return { post: presentationPost }

--- a/src/modules/post/useCases/getPost/__tests__/GetPostController.spec.ts
+++ b/src/modules/post/useCases/getPost/__tests__/GetPostController.spec.ts
@@ -3,9 +3,9 @@ import { mock } from 'jest-mock-extended'
 
 import presentationPostFactory from '../../../../../../tests/factories/presentationPostFactory'
 import { notFound, ok, serverError } from '../../../../../shared/infra/http/http'
+import { PostErrors } from '../../../shared/PostErrors'
 import { GetPost } from '../GetPost'
 import { GetPostController, GetPostControllerRequest } from '../GetPostController'
-import { GetPostErrors } from '../GetPostErrors'
 
 const makeSut = () => {
   const getPostMock = mock<GetPost>()
@@ -44,11 +44,11 @@ describe('GetPostController', () => {
     })
   })
 
-  it('should return notFound if GetUsers throws a GetPostErrors.PostNotFound errors', async () => {
+  it('should return notFound if GetUsers throws a PostErrors.PostNotFound errors', async () => {
     const { sut, getPostMock } = makeSut()
-    getPostMock.execute.mockRejectedValueOnce(new GetPostErrors.PostNotFound())
+    getPostMock.execute.mockRejectedValueOnce(new PostErrors.PostNotFound())
     const result = await sut.execute(request)
-    expect(result).toEqual(notFound(new GetPostErrors.PostNotFound()))
+    expect(result).toEqual(notFound(new PostErrors.PostNotFound()))
   })
 
   it('should return serverError if GetUsers throws a unkown error', async () => {

--- a/src/modules/post/useCases/getPost/__tests__/GetPostUseCase.spec.ts
+++ b/src/modules/post/useCases/getPost/__tests__/GetPostUseCase.spec.ts
@@ -3,6 +3,7 @@ import { mock } from 'jest-mock-extended'
 
 import postWithUserFactory from '../../../../../../tests/factories/postWithUserFactory'
 import { PostRepository } from '../../../repos/PostRepository'
+import { PostErrors } from '../../../shared/PostErrors'
 import { GetPostInputDTO } from '../GetPost'
 import { GetPostUseCase } from '../GetPostUseCase'
 
@@ -43,7 +44,7 @@ describe('GetPostUseCase', () => {
     const { sut, postRepositoryMock } = makeSut()
     postRepositoryMock.loadById.mockResolvedValueOnce(null)
     const promise = sut.execute(input)
-    expect(promise).rejects.toThrow()
+    expect(promise).rejects.toThrow(new PostErrors.PostNotFound())
   })
 
   it('should return post on success', async () => {

--- a/src/modules/post/useCases/updatePost/UpdatePost.ts
+++ b/src/modules/post/useCases/updatePost/UpdatePost.ts
@@ -1,0 +1,11 @@
+import { PresentationPost } from '../../models/PresentationPost'
+
+export interface UpdatePostInputDTO {
+  postId: string
+  title: string
+  content: string
+}
+
+export interface UpdatePost {
+  execute(data: UpdatePostInputDTO): Promise<PresentationPost>
+}

--- a/src/modules/post/useCases/updatePost/UpdatePost.ts
+++ b/src/modules/post/useCases/updatePost/UpdatePost.ts
@@ -1,9 +1,12 @@
+import { User } from '@prisma/client'
+
 import { PresentationPost } from '../../models/PresentationPost'
 
 export interface UpdatePostInputDTO {
   postId: string
   title: string
   content: string
+  userPerformingOperation: User
 }
 
 export interface UpdatePost {

--- a/src/modules/post/useCases/updatePost/UpdatePostController.ts
+++ b/src/modules/post/useCases/updatePost/UpdatePostController.ts
@@ -1,7 +1,8 @@
 import { Controller } from '../../../../shared/infra/http/Controller'
-import { badRequest, HttpAuthenticatedRequest, HttpResponse, ok, serverError } from '../../../../shared/infra/http/http'
+import { badRequest, HttpAuthenticatedRequest, HttpResponse, notFound, ok, serverError } from '../../../../shared/infra/http/http'
 import { Validator } from '../../../../validation/Validator'
 import { PresentationUpdatedPost } from '../../models/mapper/PresentationUpdatedPost'
+import { PostErrors } from '../../shared/PostErrors'
 import { UpdatePost, UpdatePostInputDTO } from './UpdatePost'
 import { UpdatePostError } from './UpdatePostErrors'
 
@@ -46,6 +47,8 @@ export class UpdatePostController extends Controller {
         switch (error.constructor) {
           case UpdatePostError.UnauthorizedToUpdatePostError:
             return badRequest(error)
+          case PostErrors.PostNotFound:
+            return notFound(error)
         }
       }
 

--- a/src/modules/post/useCases/updatePost/UpdatePostController.ts
+++ b/src/modules/post/useCases/updatePost/UpdatePostController.ts
@@ -1,0 +1,55 @@
+import { Controller } from '../../../../shared/infra/http/Controller'
+import { badRequest, HttpAuthenticatedRequest, HttpResponse, ok, serverError } from '../../../../shared/infra/http/http'
+import { Validator } from '../../../../validation/Validator'
+import { PresentationUpdatedPost } from '../../models/mapper/PresentationUpdatedPost'
+import { UpdatePost, UpdatePostInputDTO } from './UpdatePost'
+import { UpdatePostError } from './UpdatePostErrors'
+
+export type UpdatePostControllerRequest = HttpAuthenticatedRequest<{
+  title: string
+  content: string
+}, {
+  postId: string
+}>
+
+export class UpdatePostController extends Controller {
+  constructor (
+    private readonly validator: Validator,
+    private readonly updatePost: UpdatePost
+  ) {
+    super()
+  }
+
+  async execute (request: UpdatePostControllerRequest): Promise<HttpResponse<any>> {
+    try {
+      const validationError = this.validator.validate(request.body)
+      if (validationError) return badRequest(validationError)
+
+      const updatePostPayload: UpdatePostInputDTO = {
+        title: request.body!.title,
+        content: request.body!.content,
+        postId: request.params!.postId,
+        userPerformingOperation: request.authenticatedUser
+      }
+
+      const updatedPost = await this.updatePost.execute(updatePostPayload)
+
+      const presenationUpdatedPost:PresentationUpdatedPost = {
+        title: updatedPost.title,
+        content: updatedPost.content,
+        userId: updatedPost.user.id
+      }
+
+      return ok(presenationUpdatedPost)
+    } catch (error) {
+      if (error instanceof Error) {
+        switch (error.constructor) {
+          case UpdatePostError.UnauthorizedToUpdatePostError:
+            return badRequest(error)
+        }
+      }
+
+      return serverError(error)
+    }
+  }
+}

--- a/src/modules/post/useCases/updatePost/UpdatePostErrors.ts
+++ b/src/modules/post/useCases/updatePost/UpdatePostErrors.ts
@@ -1,0 +1,8 @@
+export namespace UpdatePostError {
+  export class UnauthorizedToUpdatePostError extends Error {
+    constructor () {
+      super('Usuário não autorizado')
+      this.name = 'UpdatePostError.UnauthorizedToUpdatePostError'
+    }
+  }
+}

--- a/src/modules/post/useCases/updatePost/UpdatePostUseCase.ts
+++ b/src/modules/post/useCases/updatePost/UpdatePostUseCase.ts
@@ -17,9 +17,11 @@ export class UpdatePostUseCase implements UpdatePost {
       throw new UpdatePostError.UnauthorizedToUpdatePostError()
     }
 
-    return await this.postRepository.update({
-      title: data.title,
-      content: data.content
-    })
+    return await this.postRepository.update(
+      data.postId,
+      {
+        title: data.title,
+        content: data.content
+      })
   }
 }

--- a/src/modules/post/useCases/updatePost/UpdatePostUseCase.ts
+++ b/src/modules/post/useCases/updatePost/UpdatePostUseCase.ts
@@ -1,0 +1,25 @@
+import { PresentationPost } from '../../models/PresentationPost'
+import { PostRepository } from '../../repos/PostRepository'
+import { PostErrors } from '../../shared/PostErrors'
+import { UpdatePost, UpdatePostInputDTO } from './UpdatePost'
+import { UpdatePostError } from './UpdatePostErrors'
+
+export class UpdatePostUseCase implements UpdatePost {
+  constructor (
+    private readonly postRepository: PostRepository
+  ) {}
+
+  async execute (data: UpdatePostInputDTO): Promise<PresentationPost> {
+    const post = await this.postRepository.loadById(data.postId)
+    if (!post) throw new PostErrors.PostNotFound()
+
+    if (post.user.id !== data.userPerformingOperation.id) {
+      throw new UpdatePostError.UnauthorizedToUpdatePostError()
+    }
+
+    return await this.postRepository.update({
+      title: data.title,
+      content: data.content
+    })
+  }
+}

--- a/src/modules/post/useCases/updatePost/__tests__/UpdatePostController.spec.ts
+++ b/src/modules/post/useCases/updatePost/__tests__/UpdatePostController.spec.ts
@@ -1,0 +1,107 @@
+import faker from 'faker'
+import { mock } from 'jest-mock-extended'
+
+import presentationPostFactory from '../../../../../../tests/factories/presentationPostFactory'
+import userFactory from '../../../../../../tests/factories/userFactory'
+import { badRequest, ok, serverError } from '../../../../../shared/infra/http/http'
+import { Validator } from '../../../../../validation/Validator'
+import { UpdatePost } from '../UpdatePost'
+import { UpdatePostController, UpdatePostControllerRequest } from '../UpdatePostController'
+import { UpdatePostError } from '../UpdatePostErrors'
+
+const makeSut = () => {
+  const validatorMock = mock<Validator>()
+  const updatePost = mock<UpdatePost>()
+
+  const updatedPost = presentationPostFactory(1)
+
+  // golden path mock
+  validatorMock.validate.mockReturnValue(null)
+  updatePost.execute.mockResolvedValue(updatedPost)
+
+  const sut = new UpdatePostController(
+    validatorMock,
+    updatePost
+  )
+
+  return {
+    sut,
+    validatorMock,
+    updatePost,
+    updatedPost
+  }
+}
+
+const makeRequest = (): UpdatePostControllerRequest => ({
+  authenticatedUser: userFactory(1),
+  body: {
+    title: faker.random.words(),
+    content: faker.random.words()
+  },
+  params: {
+    postId: faker.datatype.uuid()
+  }
+})
+
+describe('UpdatePostController', () => {
+  let request: UpdatePostControllerRequest
+
+  beforeEach(() => {
+    request = makeRequest()
+  })
+
+  it('should call Validator with correct values', async () => {
+    const { sut, validatorMock } = makeSut()
+    await sut.execute(request)
+    expect(validatorMock.validate).toHaveBeenCalledWith(request.body)
+  })
+
+  it('should return a badRequest with validation error if Validator returns an error', async () => {
+    const { sut, validatorMock } = makeSut()
+    validatorMock.validate.mockReturnValueOnce(new Error())
+    const response = await sut.execute(request)
+    expect(response).toEqual(badRequest(new Error()))
+  })
+
+  it('should return a serverError if Validator throws', async () => {
+    const { sut, validatorMock } = makeSut()
+    validatorMock.validate.mockImplementationOnce(() => { throw new Error() })
+    const response = await sut.execute(request)
+    expect(response).toEqual(serverError(new Error()))
+  })
+
+  it('should call UpdatePost with correct values', async () => {
+    const { sut, updatePost } = makeSut()
+    await sut.execute(request)
+    expect(updatePost.execute).toHaveBeenCalledWith({
+      title: request.body?.title,
+      content: request.body?.content,
+      postId: request.params!.postId,
+      userPerformingOperation: request.authenticatedUser
+    })
+  })
+
+  it('should a badRequest with UnauthorizedToUpdatePostError if GetPost throws a UnauthorizedToUpdatePostError', async () => {
+    const { sut, updatePost } = makeSut()
+    updatePost.execute.mockRejectedValueOnce(new UpdatePostError.UnauthorizedToUpdatePostError())
+    const response = await sut.execute(request)
+    expect(response).toEqual(badRequest(new UpdatePostError.UnauthorizedToUpdatePostError()))
+  })
+
+  it('should a serverError if GetPost throws a unkown error', async () => {
+    const { sut, updatePost } = makeSut()
+    updatePost.execute.mockRejectedValueOnce(new Error())
+    const response = await sut.execute(request)
+    expect(response).toEqual(serverError(new Error()))
+  })
+
+  it('should return ok with with PresentationUpdatedPost', async () => {
+    const { sut, updatedPost } = makeSut()
+    const response = await sut.execute(request)
+    expect(response).toEqual(ok({
+      title: updatedPost.title,
+      content: updatedPost.content,
+      userId: updatedPost.user.id
+    }))
+  })
+})

--- a/src/modules/post/useCases/updatePost/__tests__/UpdatePostController.spec.ts
+++ b/src/modules/post/useCases/updatePost/__tests__/UpdatePostController.spec.ts
@@ -3,8 +3,9 @@ import { mock } from 'jest-mock-extended'
 
 import presentationPostFactory from '../../../../../../tests/factories/presentationPostFactory'
 import userFactory from '../../../../../../tests/factories/userFactory'
-import { badRequest, ok, serverError } from '../../../../../shared/infra/http/http'
+import { badRequest, notFound, ok, serverError } from '../../../../../shared/infra/http/http'
 import { Validator } from '../../../../../validation/Validator'
+import { PostErrors } from '../../../shared/PostErrors'
 import { UpdatePost } from '../UpdatePost'
 import { UpdatePostController, UpdatePostControllerRequest } from '../UpdatePostController'
 import { UpdatePostError } from '../UpdatePostErrors'
@@ -81,14 +82,21 @@ describe('UpdatePostController', () => {
     })
   })
 
-  it('should a badRequest with UnauthorizedToUpdatePostError if GetPost throws a UnauthorizedToUpdatePostError', async () => {
+  it('should return a badRequest with UnauthorizedToUpdatePostError if UpdatePost throws a UnauthorizedToUpdatePostError', async () => {
     const { sut, updatePost } = makeSut()
     updatePost.execute.mockRejectedValueOnce(new UpdatePostError.UnauthorizedToUpdatePostError())
     const response = await sut.execute(request)
     expect(response).toEqual(badRequest(new UpdatePostError.UnauthorizedToUpdatePostError()))
   })
 
-  it('should a serverError if GetPost throws a unkown error', async () => {
+  it('should return a notFound if UpdatePost throws a PostNotFoundError', async () => {
+    const { sut, updatePost } = makeSut()
+    updatePost.execute.mockRejectedValueOnce(new PostErrors.PostNotFound())
+    const response = await sut.execute(request)
+    expect(response).toEqual(notFound(new PostErrors.PostNotFound()))
+  })
+
+  it('should a serverError if UpdatePost throws a unkown error', async () => {
     const { sut, updatePost } = makeSut()
     updatePost.execute.mockRejectedValueOnce(new Error())
     const response = await sut.execute(request)

--- a/src/modules/post/useCases/updatePost/__tests__/UpdatePostUseCase.spec.ts
+++ b/src/modules/post/useCases/updatePost/__tests__/UpdatePostUseCase.spec.ts
@@ -1,0 +1,85 @@
+import faker from 'faker'
+import { mock } from 'jest-mock-extended'
+
+import postWithUserFactory from '../../../../../../tests/factories/postWithUserFactory'
+import presentationUserFactory from '../../../../../../tests/factories/presentationUserFactory'
+import userFactory from '../../../../../../tests/factories/userFactory'
+import { PostRepository } from '../../../repos/PostRepository'
+import { PostErrors } from '../../../shared/PostErrors'
+import { UpdatePostInputDTO } from '../UpdatePost'
+import { UpdatePostError } from '../UpdatePostErrors'
+import { UpdatePostUseCase } from '../UpdatePostUseCase'
+
+const makeSut = (userIdFromInput ?: string) => {
+  const postRepositoryMock = mock<PostRepository>()
+
+  const updatedPost = postWithUserFactory(1)
+
+  // golden path mock
+  postRepositoryMock.loadById.mockResolvedValue(postWithUserFactory(1, {
+    user: presentationUserFactory(1, {
+      id: userIdFromInput || faker.datatype.uuid()
+    })
+  }))
+
+  postRepositoryMock.update.mockResolvedValue(updatedPost)
+
+  const sut = new UpdatePostUseCase(postRepositoryMock)
+
+  return {
+    sut,
+    postRepositoryMock,
+    updatedPost
+  }
+}
+
+const makeInput = (): UpdatePostInputDTO => ({
+  title: faker.random.words(),
+  content: faker.random.words(),
+  postId: faker.datatype.uuid(),
+  userPerformingOperation: userFactory(1)
+})
+
+describe('UpdatePostUseCase', () => {
+  let input: UpdatePostInputDTO
+  let userId: string
+
+  beforeEach(() => {
+    input = makeInput()
+    userId = input.userPerformingOperation.id
+  })
+
+  it('should call PostRepository.loadById with correct value', async () => {
+    const { sut, postRepositoryMock } = makeSut(userId)
+    await sut.execute(input)
+    expect(postRepositoryMock.loadById).toHaveBeenCalledWith(input.postId)
+  })
+
+  it('should throw a PostNotFound if loadById returns null', async () => {
+    const { sut, postRepositoryMock } = makeSut(userId)
+    postRepositoryMock.loadById.mockResolvedValueOnce(null)
+    const promise = sut.execute(input)
+    await expect(promise).rejects.toThrow(new PostErrors.PostNotFound())
+  })
+
+  it('should return a UnauthorizedToUpdatePostError if user is not the post author', async () => {
+    const { sut } = makeSut()
+    const promise = sut.execute(input)
+    await expect(promise).rejects.toThrow(new UpdatePostError.UnauthorizedToUpdatePostError())
+  })
+
+  it('should call PostRepository.update with correct values', async () => {
+    const { sut, postRepositoryMock } = makeSut(userId)
+    await sut.execute(input)
+    expect(postRepositoryMock.update).toHaveBeenCalledWith({
+      title: input.title,
+      content: input.content
+    })
+  })
+
+  it('should return updatePost on success', async () => {
+    const { sut, updatedPost } = makeSut(userId)
+    const result = await sut.execute(input)
+    expect(result).toEqual(updatedPost)
+  })
+})

--- a/src/modules/post/useCases/updatePost/__tests__/UpdatePostUseCase.spec.ts
+++ b/src/modules/post/useCases/updatePost/__tests__/UpdatePostUseCase.spec.ts
@@ -71,10 +71,12 @@ describe('UpdatePostUseCase', () => {
   it('should call PostRepository.update with correct values', async () => {
     const { sut, postRepositoryMock } = makeSut(userId)
     await sut.execute(input)
-    expect(postRepositoryMock.update).toHaveBeenCalledWith({
-      title: input.title,
-      content: input.content
-    })
+    expect(postRepositoryMock.update).toHaveBeenCalledWith(
+      input.postId,
+      {
+        title: input.title,
+        content: input.content
+      })
   })
 
   it('should return updatePost on success', async () => {

--- a/src/shared/infra/http/docs/api-schema.json
+++ b/src/shared/infra/http/docs/api-schema.json
@@ -370,6 +370,54 @@
             }
           }
         }
+      },
+      "put": {
+        "description": "Allows user to update their blog posts",
+        "tags": [
+          "Post"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/updatePostInput"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Post was succefully updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/updatePostPaylod"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Blog post not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errorPayload"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized or Invalid token error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errorPayload"
+                }
+              }
+            }
+          }
+        }
       }
     }
   },
@@ -454,6 +502,21 @@
           "content"
         ]
       },
+      "updatePostInput": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "content"
+        ]
+      },
       "authTokenPayload": {
         "type": "object",
         "properties": {
@@ -463,6 +526,20 @@
         }
       },
       "createPostPaylod": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "userId": {
+            "$ref": "#/components/schemas/uuid"
+          }
+        }
+      },
+      "updatePostPaylod": {
         "type": "object",
         "properties": {
           "title": {


### PR DESCRIPTION
- feat: add UpdatePost interface
- feat: add PresentationUpdatedPost model
- feat: add userPerformingOperation to UpdatePostInputDTO
- feat: add UpdatePostController
- refactor: move PostNotFoundError to shared on post module
- feat: add update mothod to PostRepository interface
- feat: add UpdatePostUseCase
- fix: handle 404 if UpdatePost does not found post
- feat: add postid to update method in PostRepository
- feat: add update implementation in PrismaPostRepository
- fix: use postId on update in UpdatePostUseCase
- feat: add PUT post/:postId route
- docs: add PUT post/postId swagger docs
- version: bump to 0.4.0 version

closes #20 