### PR TITLE
feature/issue 22

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postpress",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "1. [Database](./docs/database.md) 2. Routes    1. [User](./docs/user-routes.md)",
   "main": "index.js",
   "directories": {

--- a/src/modules/post/repos/PostRepository.ts
+++ b/src/modules/post/repos/PostRepository.ts
@@ -13,9 +13,14 @@ export interface PostRepositoryUpdateDTO {
   content: string
 }
 
+export interface PostRepositoryFindBySearchDTO {
+  searchTerm?: string
+}
+
 export interface PostRepository {
   create(data: PostRepositoryCreateDTO): Promise<PostWithUser>
   getAll(): Promise<PostWithUser[]>
   loadById(id: string): Promise<PostWithUser | null>
   update(postId: string, dataToUpdate: PostRepositoryUpdateDTO): Promise<PostWithUser>
+  findBySearch(query?: PostRepositoryFindBySearchDTO): Promise<PostWithUser[]>
 }

--- a/src/modules/post/repos/implementations/PrismaPostRepository.test.ts
+++ b/src/modules/post/repos/implementations/PrismaPostRepository.test.ts
@@ -121,4 +121,86 @@ describe('PrismaPostRepository', () => {
       expect(updatedPost!.user.id).toEqual(user.id)
     })
   })
+
+  describe('findBySearch', () => {
+    it('should search for post by title or content when searchTerm is provided', async () => {
+      const user = await prisma.user.create({
+        data: userFactory(1)
+      })
+      const createdPost = await prisma.post.create({
+        data: {
+          title: 'super title',
+          content: 'my post content',
+          user: {
+            connect: {
+              id: user.id
+            }
+          }
+        },
+        include: { user: true }
+      })
+
+      await (async () => {
+        const posts = await sut.findBySearch({
+          searchTerm: 'title'
+        })
+        expect(posts).toEqual([createdPost])
+      })()
+
+      await (async () => {
+        const posts = await sut.findBySearch({
+          searchTerm: 'super ti'
+        })
+        expect(posts).toEqual([createdPost])
+      })()
+
+      await (async () => {
+        const posts = await sut.findBySearch({
+          searchTerm: 'post'
+        })
+        expect(posts).toEqual([createdPost])
+      })()
+
+      await (async () => {
+        const posts = await sut.findBySearch({
+          searchTerm: 'post content'
+        })
+        expect(posts).toEqual([createdPost])
+      })()
+    })
+
+    it('should return all posts if no searchTerm is provided', async () => {
+      const user = await prisma.user.create({
+        data: userFactory(1)
+      })
+      await prisma.post.create({
+        data: {
+          title: 'super title',
+          content: 'my post content',
+          user: {
+            connect: {
+              id: user.id
+            }
+          }
+        },
+        include: { user: true }
+      })
+
+      await prisma.post.create({
+        data: {
+          title: 'super title',
+          content: 'my post content',
+          user: {
+            connect: {
+              id: user.id
+            }
+          }
+        },
+        include: { user: true }
+      })
+
+      const posts = await sut.findBySearch({})
+      expect(posts.length).toEqual(2)
+    })
+  })
 })

--- a/src/modules/post/repos/implementations/PrismaPostRepository.ts
+++ b/src/modules/post/repos/implementations/PrismaPostRepository.ts
@@ -1,6 +1,6 @@
-import { PrismaClient } from '@prisma/client'
+import { Prisma, PrismaClient } from '@prisma/client'
 
-import { PostRepository, PostRepositoryCreateDTO, PostRepositoryUpdateDTO, PostWithUser } from '../PostRepository'
+import { PostRepository, PostRepositoryCreateDTO, PostRepositoryFindBySearchDTO, PostRepositoryUpdateDTO, PostWithUser } from '../PostRepository'
 
 export class PrismaPostRepository implements PostRepository {
   constructor (private readonly prisma: PrismaClient) {}
@@ -42,6 +42,26 @@ export class PrismaPostRepository implements PostRepository {
       include: {
         user: true
       }
+    })
+  }
+
+  findBySearch (query?: PostRepositoryFindBySearchDTO): Promise<PostWithUser[]> {
+    let where: Prisma.PostWhereInput = {}
+
+    if (query?.searchTerm) {
+      const searchTerm = query.searchTerm
+      where = {
+        ...where,
+        OR: [
+          { title: { contains: searchTerm } },
+          { content: { contains: searchTerm } }
+        ]
+      }
+    }
+
+    return this.prisma.post.findMany({
+      where,
+      include: { user: true }
     })
   }
 }

--- a/src/modules/post/useCases/postSearch/PostSearch.ts
+++ b/src/modules/post/useCases/postSearch/PostSearch.ts
@@ -1,0 +1,13 @@
+import { PresentationPost } from '../../models/PresentationPost'
+
+export interface PostSearchInputDTO {
+  searchTerm?: string
+}
+
+export interface PostSearchReponseDTO {
+  posts: PresentationPost[]
+}
+
+export interface PostSearch {
+  execute(data: PostSearchInputDTO): Promise<PostSearchReponseDTO>
+}

--- a/src/modules/post/useCases/postSearch/PostSearchController.ts
+++ b/src/modules/post/useCases/postSearch/PostSearchController.ts
@@ -1,0 +1,31 @@
+import { Controller } from '../../../../shared/infra/http/Controller'
+import { HttpAuthenticatedRequest, HttpResponse, ok, serverError } from '../../../../shared/infra/http/http'
+import { PostSearch, PostSearchInputDTO } from './PostSearch'
+
+export type PostSearchControllerRequest = HttpAuthenticatedRequest<undefined, undefined, {
+  q?: string
+}>
+
+export class PostSearchController extends Controller {
+  constructor (private readonly postSearch: PostSearch) {
+    super()
+  }
+
+  async execute (request: PostSearchControllerRequest): Promise<HttpResponse<any>> {
+    try {
+      const postSearchInput = this.makePostSearchInput(request)
+      const { posts } = await this.postSearch.execute(postSearchInput)
+      return ok(posts)
+    } catch (error) {
+      return serverError(error)
+    }
+  }
+
+  private makePostSearchInput (request: PostSearchControllerRequest): PostSearchInputDTO {
+    const queryParams: PostSearchInputDTO = {}
+    if (request?.query?.q) {
+      queryParams.searchTerm = request.query.q
+    }
+    return queryParams
+  }
+}

--- a/src/modules/post/useCases/postSearch/PostSearchUseCase.ts
+++ b/src/modules/post/useCases/postSearch/PostSearchUseCase.ts
@@ -1,0 +1,15 @@
+import { PostMapper } from '../../models/mapper/PostMapper'
+import { PostRepository } from '../../repos/PostRepository'
+import { PostSearch, PostSearchInputDTO, PostSearchReponseDTO } from './PostSearch'
+
+export class PostSearchUseCase implements PostSearch {
+  constructor (private readonly postRepostiory: PostRepository) {}
+
+  async execute (data: PostSearchInputDTO): Promise<PostSearchReponseDTO> {
+    const posts = await this.postRepostiory.findBySearch({
+      searchTerm: data.searchTerm
+    })
+
+    return { posts: PostMapper.toPresentations(posts) }
+  }
+}

--- a/src/modules/post/useCases/postSearch/__tests__/PostSeachController.spec.ts
+++ b/src/modules/post/useCases/postSearch/__tests__/PostSeachController.spec.ts
@@ -1,0 +1,68 @@
+import faker from 'faker'
+import { mock } from 'jest-mock-extended'
+
+import presentationPostFactory from '../../../../../../tests/factories/presentationPostFactory'
+import userFactory from '../../../../../../tests/factories/userFactory'
+import { ok, serverError } from '../../../../../shared/infra/http/http'
+import { PostSearch } from '../PostSearch'
+import { PostSearchController, PostSearchControllerRequest } from '../PostSearchController'
+
+const makeSut = () => {
+  const postSearchUseCaseMock = mock<PostSearch>()
+
+  // golden path mock
+  const posts = presentationPostFactory(2)
+  postSearchUseCaseMock.execute.mockResolvedValue({ posts })
+  const sut = new PostSearchController(postSearchUseCaseMock)
+
+  return {
+    sut,
+    postSearchUseCaseMock,
+    posts
+  }
+}
+
+const makeRequest = (): PostSearchControllerRequest => ({
+  authenticatedUser: userFactory(1),
+  query: {
+    q: faker.random.words()
+  }
+})
+
+describe('PostSearchController', () => {
+  let request:PostSearchControllerRequest
+
+  beforeEach(() => {
+    request = makeRequest()
+  })
+
+  it('should call PostSearch with correct value based on request params', async () => {
+    const { sut, postSearchUseCaseMock } = makeSut()
+    await sut.execute(request)
+    expect(postSearchUseCaseMock.execute).toHaveBeenCalledWith({
+      searchTerm: request.query!.q
+    })
+  })
+
+  it('should call PostSearch with empty object if no query params is provided', async () => {
+    const { sut, postSearchUseCaseMock } = makeSut()
+    await sut.execute({
+      authenticatedUser: request.authenticatedUser,
+      query: undefined
+    })
+    expect(postSearchUseCaseMock.execute).toHaveBeenCalledWith({})
+  })
+
+  it('should return serverError if PostSearch throws an error', async () => {
+    const { sut, postSearchUseCaseMock } = makeSut()
+    postSearchUseCaseMock.execute.mockRejectedValueOnce(new Error())
+    const result = await sut.execute(request)
+    expect(result).toEqual(serverError(new Error()))
+  })
+
+  it('should return posts on success', async () => {
+    const { sut, posts } = makeSut()
+    const result = await sut.execute(request)
+    expect(result).toEqual(ok(posts))
+  })
+})

--- a/src/modules/post/useCases/postSearch/__tests__/PostSearchUseCase.spec.ts
+++ b/src/modules/post/useCases/postSearch/__tests__/PostSearchUseCase.spec.ts
@@ -1,0 +1,46 @@
+import faker from 'faker'
+import { mock } from 'jest-mock-extended'
+
+import postWithUserFactory from '../../../../../../tests/factories/postWithUserFactory'
+import { PostMapper } from '../../../models/mapper/PostMapper'
+import { PostRepository } from '../../../repos/PostRepository'
+import { PostSearchInputDTO } from '../PostSearch'
+import { PostSearchUseCase } from '../PostSearchUseCase'
+
+const makeSut = () => {
+  const postRepositoryMock = mock<PostRepository>()
+
+  // golden path mock
+  const posts = postWithUserFactory(2)
+  postRepositoryMock.findBySearch.mockResolvedValue(posts)
+
+  const sut = new PostSearchUseCase(postRepositoryMock)
+
+  return { sut, postRepositoryMock, posts }
+}
+
+const makeInput = (): PostSearchInputDTO => ({
+  searchTerm: faker.random.words()
+})
+
+describe('PostSearchUseCase', () => {
+  let input: PostSearchInputDTO
+
+  beforeEach(() => {
+    input = makeInput()
+  })
+
+  it('should call PostRepository.findBySearch with correct values', async () => {
+    const { sut, postRepositoryMock } = makeSut()
+    await sut.execute(input)
+    expect(postRepositoryMock.findBySearch).toHaveBeenCalledWith({
+      searchTerm: input.searchTerm
+    })
+  })
+
+  it('should return mapped posts on sucess', async () => {
+    const { sut, posts } = makeSut()
+    const result = await sut.execute(input)
+    expect(result.posts).toEqual(PostMapper.toPresentations(posts))
+  })
+})

--- a/src/shared/infra/adapters/expressRouteAdapter.ts
+++ b/src/shared/infra/adapters/expressRouteAdapter.ts
@@ -32,6 +32,7 @@ export const expressAuthenticatedRouteAdapter: ExpressRouteAdapter = (controller
     const payload: HttpAuthenticatedRequest = {
       params: req?.params ?? {},
       body: req.body,
+      query: req.query,
       authenticatedUser: req.authenticatedUser
     }
 

--- a/src/shared/infra/http/docs/api-schema.json
+++ b/src/shared/infra/http/docs/api-schema.json
@@ -236,6 +236,11 @@
     },
     "/post": {
       "post": {
+        "security": [
+          {
+            "authorization": []
+          }
+        ],
         "description": "Route creating a new blog post",
         "tags": [
           "Post"
@@ -285,6 +290,11 @@
         }
       },
       "get": {
+        "security": [
+          {
+            "authorization": []
+          }
+        ],
         "description": "Route listing all blog posts",
         "tags": [
           "Post"
@@ -371,6 +381,11 @@
         }
       },
       "put": {
+        "security": [
+          {
+            "authorization": []
+          }
+        ],
         "description": "Allows user to update their blog posts",
         "tags": [
           "Post"

--- a/src/shared/infra/http/docs/api-schema.json
+++ b/src/shared/infra/http/docs/api-schema.json
@@ -295,7 +295,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type":"array",
+                  "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/presentationPost"
                   }
@@ -303,7 +303,6 @@
               }
             }
           },
-          
           "401": {
             "description": "Unauthorized or Invalid token error",
             "content": {
@@ -409,6 +408,54 @@
           },
           "401": {
             "description": "Unauthorized or Invalid token error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errorPayload"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/post/search": {
+      "parameters": [
+        {
+          "in": "query",
+          "name": "q",
+          "schema": {
+            "type": "string"
+          },
+          "description": "Filter posts that contains the searchTerm in title or content"
+        }
+      ],
+      "get": {
+        "description": "Search for posts, if no parameters are set it will return all posts",
+        "security": [
+          {
+            "authorization": []
+          }
+        ],
+        "tags": [
+          "Post"
+        ],
+        "responses": {
+          "200": {
+            "description": "Blog pots",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/presentationPost"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Return a unauthorized or invalid token error",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/shared/infra/http/http.ts
+++ b/src/shared/infra/http/http.ts
@@ -2,15 +2,17 @@ import { User } from '@prisma/client'
 
 import { AppErrors } from '../../errors/AppErrors'
 
-export interface HttpRequest<T = any, P = any> {
+export interface HttpRequest<T = any, P = any, Q = any> {
   body?: T
   params?:P
+  query?: Q
   authenticatedUser?: User
 }
 
-export interface HttpAuthenticatedRequest<T = any, P = any> {
+export interface HttpAuthenticatedRequest<T = any, P = any, Q = any> {
   body?: T
   params?:P
+  query?: Q
   authenticatedUser: User
 }
 

--- a/src/shared/infra/http/routes/post.ts
+++ b/src/shared/infra/http/routes/post.ts
@@ -10,6 +10,8 @@ import { GetPostController } from '../../../../modules/post/useCases/getPost/Get
 import { GetPostUseCase } from '../../../../modules/post/useCases/getPost/GetPostUseCase'
 import { GetPostsController } from '../../../../modules/post/useCases/getPosts/GetPostsController'
 import { GetPostsUseCase } from '../../../../modules/post/useCases/getPosts/GetPostsUseCase'
+import { PostSearchController } from '../../../../modules/post/useCases/postSearch/PostSearchController'
+import { PostSearchUseCase } from '../../../../modules/post/useCases/postSearch/PostSearchUseCase'
 import { UpdatePostController } from '../../../../modules/post/useCases/updatePost/UpdatePostController'
 import { UpdatePostUseCase } from '../../../../modules/post/useCases/updatePost/UpdatePostUseCase'
 import { expressMiddlewareAdapter } from '../../adapters/expressMiddlewareAdapter'
@@ -52,6 +54,12 @@ const makeUpdatePostController = (prisma: PrismaClient) => {
   return new UpdatePostController(updatePostValidator, updatePostUseCase)
 }
 
+const makePostSearchController = (prisma: PrismaClient) => {
+  const prismaPostRepository = new PrismaPostRepository(prisma)
+  const postSearchUseCase = new PostSearchUseCase(prismaPostRepository)
+  return new PostSearchController(postSearchUseCase)
+}
+
 export const makePostRoutes = (prisma: PrismaClient) => {
   const router = Router()
   router.post('/post',
@@ -62,6 +70,11 @@ export const makePostRoutes = (prisma: PrismaClient) => {
   router.get('/post',
     expressMiddlewareAdapter(new AuthMidddleware(makeJwtAdapter(), makePrismaUserRepository(prisma))),
     expressAuthenticatedRouteAdapter(makeGetPostsController(prisma))
+  )
+
+  router.get('/post/search',
+    expressMiddlewareAdapter(new AuthMidddleware(makeJwtAdapter(), makePrismaUserRepository(prisma))),
+    expressAuthenticatedRouteAdapter(makePostSearchController(prisma))
   )
 
   router.get('/post/:postId',


### PR DESCRIPTION
- feat: add query params to HttpRequest interfaces
- feat: add PostSearch use case interface
- feat: add PostSearchController
- test: add PostSearchController unit tests
- feat: add findBySearch to PostRepository interface
- feat: add PostSearchUseCase
- test: add PostSearchUseCase unit tests
- feat: add findBySearch implementation
- test: add findBySearch implementation integration tests
- feat: add GET posts/search route
- test: add integration tests for GET post/search route
- docs: add GET posts/search swagger docs
- docs: add auth to routes
- version: bump to version 0.5.0

closes #22 
