### PR TITLE
feature/issue 24: delete post

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postpress",
-  "version": "0.5.0",
+  "version": "1.0.0",
   "description": "1. [Database](./docs/database.md) 2. Routes    1. [User](./docs/user-routes.md)",
   "main": "index.js",
   "directories": {

--- a/src/modules/post/repos/PostRepository.ts
+++ b/src/modules/post/repos/PostRepository.ts
@@ -23,4 +23,5 @@ export interface PostRepository {
   loadById(id: string): Promise<PostWithUser | null>
   update(postId: string, dataToUpdate: PostRepositoryUpdateDTO): Promise<PostWithUser>
   findBySearch(query?: PostRepositoryFindBySearchDTO): Promise<PostWithUser[]>
+  deletePostById(id: string): Promise<PostWithUser>
 }

--- a/src/modules/post/repos/implementations/PrismaPostRepository.test.ts
+++ b/src/modules/post/repos/implementations/PrismaPostRepository.test.ts
@@ -203,4 +203,26 @@ describe('PrismaPostRepository', () => {
       expect(posts.length).toEqual(2)
     })
   })
+
+  describe('deletePostById', () => {
+    it('should return deleted post on success', async () => {
+      const user = await prisma.user.create({
+        data: userFactory(1)
+      })
+      const createdPost = await prisma.post.create({
+        data: {
+          ...omit(postFactory(1), 'userId'),
+          user: {
+            connect: {
+              id: user.id
+            }
+          }
+        }
+      })
+
+      const updatedPost = await sut.deletePostById(createdPost.id)
+      expect(updatedPost!.id).toBeDefined()
+      expect(updatedPost!.user.id).toEqual(user.id)
+    })
+  })
 })

--- a/src/modules/post/repos/implementations/PrismaPostRepository.ts
+++ b/src/modules/post/repos/implementations/PrismaPostRepository.ts
@@ -64,4 +64,11 @@ export class PrismaPostRepository implements PostRepository {
       include: { user: true }
     })
   }
+
+  deletePostById (id: string): Promise<PostWithUser> {
+    return this.prisma.post.delete({
+      where: { id },
+      include: { user: true }
+    })
+  }
 }

--- a/src/modules/post/useCases/deletePost/DeletePost.ts
+++ b/src/modules/post/useCases/deletePost/DeletePost.ts
@@ -1,0 +1,12 @@
+import { User } from '@prisma/client'
+
+import { PresentationPost } from '../../models/PresentationPost'
+
+export interface DeletePostInputDTO {
+  postId: string
+  userPerformingOperation: User
+}
+
+export interface DeletePost {
+  execute(data: DeletePostInputDTO): Promise<PresentationPost>
+}

--- a/src/modules/post/useCases/deletePost/DeletePost.ts
+++ b/src/modules/post/useCases/deletePost/DeletePost.ts
@@ -1,12 +1,10 @@
 import { User } from '@prisma/client'
 
-import { PresentationPost } from '../../models/PresentationPost'
-
 export interface DeletePostInputDTO {
   postId: string
   userPerformingOperation: User
 }
 
 export interface DeletePost {
-  execute(data: DeletePostInputDTO): Promise<PresentationPost>
+  execute(data: DeletePostInputDTO): Promise<void>
 }

--- a/src/modules/post/useCases/deletePost/DeletePostController.ts
+++ b/src/modules/post/useCases/deletePost/DeletePostController.ts
@@ -1,0 +1,37 @@
+import { Controller } from '../../../../shared/infra/http/Controller'
+import { HttpAuthenticatedRequest, HttpResponse, noContent, notFound, serverError, unauthorized } from '../../../../shared/infra/http/http'
+import { PostErrors } from '../../shared/PostErrors'
+import { DeletePost } from './DeletePost'
+import { DeletePostErrors } from './DeletePostErrors'
+
+export type DeletePostControllerRequest = HttpAuthenticatedRequest<undefined, {
+  postId: string
+}>
+
+export class DeletePostController extends Controller {
+  constructor (
+    private readonly deletePostUseCase: DeletePost
+  ) {
+    super()
+  }
+
+  async execute (request: DeletePostControllerRequest): Promise<HttpResponse<any>> {
+    try {
+      await this.deletePostUseCase.execute({
+        postId: request.params!.postId,
+        userPerformingOperation: request.authenticatedUser
+      })
+      return noContent()
+    } catch (error) {
+      if (error instanceof Error) {
+        switch (error.constructor) {
+          case PostErrors.PostNotFound:
+            return notFound(error)
+          case DeletePostErrors.UnauthorizedToDeletePostError:
+            return unauthorized(error)
+        }
+      }
+      return serverError(error)
+    }
+  }
+}

--- a/src/modules/post/useCases/deletePost/DeletePostErrors.ts
+++ b/src/modules/post/useCases/deletePost/DeletePostErrors.ts
@@ -1,0 +1,8 @@
+export namespace DeletePostErrors {
+  export class UnauthorizedToDeletePostError extends Error {
+    constructor () {
+      super('Usuário não autorizado')
+      this.name = 'DeletePostError.UnauthorizedToDeletePostError'
+    }
+  }
+}

--- a/src/modules/post/useCases/deletePost/DeletePostUseCase.ts
+++ b/src/modules/post/useCases/deletePost/DeletePostUseCase.ts
@@ -1,0 +1,19 @@
+import { PostRepository } from '../../repos/PostRepository'
+import { PostErrors } from '../../shared/PostErrors'
+import { DeletePost, DeletePostInputDTO } from './DeletePost'
+import { DeletePostErrors } from './DeletePostErrors'
+
+export class DeletePostUseCase implements DeletePost {
+  constructor (private readonly postRepository: PostRepository) {}
+
+  async execute (data: DeletePostInputDTO): Promise<void> {
+    const post = await this.postRepository.loadById(data.postId)
+    if (!post) throw new PostErrors.PostNotFound()
+
+    if (post.user.id !== data.userPerformingOperation.id) {
+      throw new DeletePostErrors.UnauthorizedToDeletePostError()
+    }
+
+    await this.postRepository.deletePostById(data.postId)
+  }
+}

--- a/src/modules/post/useCases/deletePost/__tests__/DeletePostController.spec.ts
+++ b/src/modules/post/useCases/deletePost/__tests__/DeletePostController.spec.ts
@@ -1,7 +1,6 @@
 import faker from 'faker'
 import { mock } from 'jest-mock-extended'
 
-import presentationPostFactory from '../../../../../../tests/factories/presentationPostFactory'
 import userFactory from '../../../../../../tests/factories/userFactory'
 import { noContent, notFound, serverError, unauthorized } from '../../../../../shared/infra/http/http'
 import { PostErrors } from '../../../shared/PostErrors'
@@ -12,7 +11,7 @@ import { DeletePostErrors } from '../DeletePostErrors'
 const makeSut = () => {
   const deletePostUseCaseMock = mock<DeletePost>()
 
-  deletePostUseCaseMock.execute.mockResolvedValue(presentationPostFactory(1))
+  deletePostUseCaseMock.execute.mockResolvedValue()
 
   const sut = new DeletePostController(deletePostUseCaseMock)
 

--- a/src/modules/post/useCases/deletePost/__tests__/DeletePostController.spec.ts
+++ b/src/modules/post/useCases/deletePost/__tests__/DeletePostController.spec.ts
@@ -1,0 +1,71 @@
+import faker from 'faker'
+import { mock } from 'jest-mock-extended'
+
+import presentationPostFactory from '../../../../../../tests/factories/presentationPostFactory'
+import userFactory from '../../../../../../tests/factories/userFactory'
+import { noContent, notFound, serverError, unauthorized } from '../../../../../shared/infra/http/http'
+import { PostErrors } from '../../../shared/PostErrors'
+import { DeletePost } from '../DeletePost'
+import { DeletePostController, DeletePostControllerRequest } from '../DeletePostController'
+import { DeletePostErrors } from '../DeletePostErrors'
+
+const makeSut = () => {
+  const deletePostUseCaseMock = mock<DeletePost>()
+
+  deletePostUseCaseMock.execute.mockResolvedValue(presentationPostFactory(1))
+
+  const sut = new DeletePostController(deletePostUseCaseMock)
+
+  return { sut, deletePostUseCaseMock }
+}
+
+const makeRequest = (): DeletePostControllerRequest => ({
+  authenticatedUser: userFactory(1),
+  params: {
+    postId: faker.datatype.uuid()
+  }
+})
+
+describe('DeletePostController', () => {
+  let request: DeletePostControllerRequest
+
+  beforeEach(() => {
+    request = makeRequest()
+  })
+
+  it('should call DeletePost with correct values', async () => {
+    const { sut, deletePostUseCaseMock } = makeSut()
+    await sut.handle(request)
+    expect(deletePostUseCaseMock.execute).toHaveBeenCalledWith({
+      postId: request.params?.postId,
+      userPerformingOperation: request.authenticatedUser
+    })
+  })
+
+  it('should return serverError if DeletePost throws unkown error', async () => {
+    const { sut, deletePostUseCaseMock } = makeSut()
+    deletePostUseCaseMock.execute.mockRejectedValueOnce(new Error())
+    const response = await sut.handle(request)
+    expect(response).toEqual(serverError(new Error()))
+  })
+
+  it('should return notFound if DeletePost throws PostNotFoundError', async () => {
+    const { sut, deletePostUseCaseMock } = makeSut()
+    deletePostUseCaseMock.execute.mockRejectedValueOnce(new PostErrors.PostNotFound())
+    const response = await sut.handle(request)
+    expect(response).toEqual(notFound(new PostErrors.PostNotFound()))
+  })
+
+  it('should return unauthorized if DeletePost throws UnauthorizedToDeletePostError', async () => {
+    const { sut, deletePostUseCaseMock } = makeSut()
+    deletePostUseCaseMock.execute.mockRejectedValueOnce(new DeletePostErrors.UnauthorizedToDeletePostError())
+    const response = await sut.handle(request)
+    expect(response).toEqual(unauthorized(new DeletePostErrors.UnauthorizedToDeletePostError()))
+  })
+
+  it('should return noContent on success', async () => {
+    const { sut } = makeSut()
+    const response = await sut.handle(request)
+    expect(response).toEqual(noContent())
+  })
+})

--- a/src/modules/post/useCases/deletePost/__tests__/DeletePostUseCase.spec.ts
+++ b/src/modules/post/useCases/deletePost/__tests__/DeletePostUseCase.spec.ts
@@ -1,0 +1,71 @@
+import faker from 'faker'
+import { mock } from 'jest-mock-extended'
+
+import postWithUserFactory from '../../../../../../tests/factories/postWithUserFactory'
+import presentationUserFactory from '../../../../../../tests/factories/presentationUserFactory'
+import userFactory from '../../../../../../tests/factories/userFactory'
+import { PostRepository } from '../../../repos/PostRepository'
+import { PostErrors } from '../../../shared/PostErrors'
+import { DeletePostInputDTO } from '../DeletePost'
+import { DeletePostErrors } from '../DeletePostErrors'
+import { DeletePostUseCase } from '../DeletePostUseCase'
+
+const makeSut = (userId?: string) => {
+  const postRepositoryMock = mock<PostRepository>()
+
+  // golden path mock
+  postRepositoryMock.loadById.mockResolvedValue(
+    postWithUserFactory(1, {
+      user: presentationUserFactory(1, {
+        id: userId || faker.datatype.uuid()
+      })
+    })
+  )
+
+  const sut = new DeletePostUseCase(postRepositoryMock)
+
+  return {
+    sut,
+    postRepositoryMock
+  }
+}
+
+const makeInput = ():DeletePostInputDTO => ({
+  postId: faker.datatype.uuid(),
+  userPerformingOperation: userFactory(1)
+})
+
+describe('DeletePostUseCase', () => {
+  let input:DeletePostInputDTO
+  let userId: string
+
+  beforeEach(() => {
+    input = makeInput()
+    userId = input.userPerformingOperation.id
+  })
+
+  it('should call PostRepository.loadByid with correct value', async () => {
+    const { sut, postRepositoryMock } = makeSut(userId)
+    await sut.execute(input)
+    expect(postRepositoryMock.loadById).toHaveBeenCalledWith(input.postId)
+  })
+
+  it('should throw a PostNotFound error if post is not found', async () => {
+    const { sut, postRepositoryMock } = makeSut()
+    postRepositoryMock.loadById.mockResolvedValueOnce(null)
+    const promise = sut.execute(input)
+    await expect(promise).rejects.toThrow(new PostErrors.PostNotFound())
+  })
+
+  it('should throw a UnauthorizedToDeletePostError if user is not the post author', async () => {
+    const { sut } = makeSut(faker.datatype.uuid())
+    const promise = sut.execute(input)
+    await expect(promise).rejects.toThrow(new DeletePostErrors.UnauthorizedToDeletePostError())
+  })
+
+  it('should call PostRepository.deletePostById with correct value', async () => {
+    const { sut, postRepositoryMock } = makeSut(userId)
+    await sut.execute(input)
+    expect(postRepositoryMock.deletePostById).toHaveBeenCalledWith(input.postId)
+  })
+})

--- a/src/shared/infra/http/docs/api-schema.json
+++ b/src/shared/infra/http/docs/api-schema.json
@@ -432,6 +432,52 @@
             }
           }
         }
+      },
+      "delete": {
+        "security": [
+          {
+            "authorization": []
+          }
+        ],
+        "description": "Allows blog posts author to delete the post",
+        "tags": [
+          "Post"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/updatePostInput"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Post was succefully deleted"
+          },
+          "404": {
+            "description": "Blog post not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errorPayload"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized or Invalid token error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errorPayload"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/post/search": {

--- a/src/shared/infra/http/routes/post.ts
+++ b/src/shared/infra/http/routes/post.ts
@@ -6,6 +6,8 @@ import { JoiValidatorAdapter } from '../../../../infra/adapters/validation/JoiVa
 import { PrismaPostRepository } from '../../../../modules/post/repos/implementations/PrismaPostRepository'
 import { CreatePostController } from '../../../../modules/post/useCases/createPost/CreatePostController'
 import { CreatePostUseCase } from '../../../../modules/post/useCases/createPost/CreatePostUseCase'
+import { DeletePostController } from '../../../../modules/post/useCases/deletePost/DeletePostController'
+import { DeletePostUseCase } from '../../../../modules/post/useCases/deletePost/DeletePostUseCase'
 import { GetPostController } from '../../../../modules/post/useCases/getPost/GetPostController'
 import { GetPostUseCase } from '../../../../modules/post/useCases/getPost/GetPostUseCase'
 import { GetPostsController } from '../../../../modules/post/useCases/getPosts/GetPostsController'
@@ -60,6 +62,12 @@ const makePostSearchController = (prisma: PrismaClient) => {
   return new PostSearchController(postSearchUseCase)
 }
 
+const makeDeletePostController = (prisma: PrismaClient) => {
+  const prismaPostRepository = new PrismaPostRepository(prisma)
+  const deletePostUseCase = new DeletePostUseCase(prismaPostRepository)
+  return new DeletePostController(deletePostUseCase)
+}
+
 export const makePostRoutes = (prisma: PrismaClient) => {
   const router = Router()
   router.post('/post',
@@ -85,6 +93,11 @@ export const makePostRoutes = (prisma: PrismaClient) => {
   router.put('/post/:postId',
     expressMiddlewareAdapter(new AuthMidddleware(makeJwtAdapter(), makePrismaUserRepository(prisma))),
     expressAuthenticatedRouteAdapter(makeUpdatePostController(prisma))
+  )
+
+  router.delete('/post/:postId',
+    expressMiddlewareAdapter(new AuthMidddleware(makeJwtAdapter(), makePrismaUserRepository(prisma))),
+    expressAuthenticatedRouteAdapter(makeDeletePostController(prisma))
   )
   return router
 }


### PR DESCRIPTION
- feat: add DeletePost use case interface
- feat: add DeletePostController
- test: add DeletePostController unit tests
- feat: add deletePostById to PostRepository
- refactor: change the return type of DeletePost to Promise void
- feat: add DeletePostUseCase
- test: add DeletePostUseCase unit test
- feat: add deletePostById implementation to PrismaPostRepository
- test: add deletePostById integration tests
- feat: add DELETE post/:postId route
- test: add integration tests to DELETE post/:postId route
- docs: add DELTE post/:postId swagger docs
- version: bump version to 1.0.0

closes #24 
